### PR TITLE
Fix cart sidebar width on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,8 @@
             background: linear-gradient(135deg, #1a2a6c, #b21f1f, #fdbb2d);
             color: #333;
             line-height: 1.6;
-        }       
+            overflow-x: hidden;
+        }
         
         .container {
             max-width: 1200px;
@@ -311,19 +312,20 @@
         .cart-container {
             position: fixed;
             top: 0;
-            right: -400px;
+            right: 0;
             width: 100%;
             max-width: 380px;
             height: 100vh;
             background: white;
             box-shadow: -5px 0 15px rgba(0, 0, 0, 0.2);
-            transition: right 0.4s ease;
+            transition: transform 0.4s ease;
             z-index: 1000;
             overflow-y: auto;
+            transform: translateX(100%);
         }
-        
+
         .cart-container.open {
-            right: 0;
+            transform: translateX(0);
         }
         
         .cart-header {


### PR DESCRIPTION
## Summary
- ensure body doesn't scroll horizontally
- slide cart with CSS transforms so it stays off-screen on small devices

## Testing
- `npx stylelint styles.css` *(fails: npm missing stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_684b223211848323a61ca3f0beda43bb